### PR TITLE
fix delayed_asattr when proxy is uninferrable

### DIFF
--- a/astroid/builder.py
+++ b/astroid/builder.py
@@ -237,6 +237,8 @@ class AstroidBuilder(raw_building.InspectBuilder):
                 try:
                     if inferred.__class__ is bases.Instance:
                         inferred = inferred._proxied
+                        if inferred is util.Uninferable:
+                            continue
                         iattrs = inferred.instance_attrs
                         if not _can_assign_attr(inferred, node.attrname):
                             continue


### PR DESCRIPTION
### Fixes / new features
- 

added a check to prevent trying to get instance_attrs from node with
an uninferrable proxy.